### PR TITLE
Valida os dados do login com Telegram

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -72,6 +72,8 @@ config :guilda, GuildaWeb.Endpoint,
     ]
   ]
 
+config :guilda, :environment, :dev
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,14 +16,7 @@ config :guilda, Guilda.Repo,
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :guilda, GuildaWeb.Endpoint,
-  url: [host: "guildatech.dev"],
-  http: [port: 4010],
-  https: [
-    port: 443,
-    cipher_suite: :strong,
-    certfile: "priv/cert/guildatech.dev.crt",
-    keyfile: "priv/cert/guildatech.dev.key"
-  ],
+  http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -57,4 +57,13 @@ config :guilda, GuildaWeb.Endpoint, force_ssl: [rewrite_on: [:x_forwarded_proto]
 
 # Finally import the config/prod.secret.exs which loads secrets
 # and configuration from environment variables.
+
+telegram_bot_token =
+  System.get_env("TELEGRAM_BOT_TOKEN") ||
+    raise """
+    environment variable TELEGRAM_BOT_TOKEN is missing.
+    """
+
+config :guilda, :auth, telegram_bot_token: telegram_bot_token
+
 import_config "prod.secret.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -66,4 +66,6 @@ telegram_bot_token =
 
 config :guilda, :auth, telegram_bot_token: telegram_bot_token
 
+config :guilda, :environment, :prod
+
 import_config "prod.secret.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,3 +23,7 @@ config :guilda, GuildaWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+config :guilda, :auth, telegram_bot_token: "1328041770:AAG7GlDdKF2FVEmYjHFNNFKj9UVhDOKmtqc"
+
+config :guilda, :environment, :test

--- a/lib/guilda_web/router.ex
+++ b/lib/guilda_web/router.ex
@@ -11,10 +11,6 @@ defmodule GuildaWeb.Router do
       ws://localhost:*
       wss://localhost:*
       http://localhost:*
-      ws://guildatech.dev:*
-      wss://guildatech.dev:*
-      http://guildatech.dev:*
-      https://guildatech.dev:*
       http://guildatech.gigalixirapp.com
       https://guildatech.gigalixirapp.com
       ws://guildatech.gigalixirapp.com

--- a/lib/guilda_web/templates/page/index.html.leex
+++ b/lib/guilda_web/templates/page/index.html.leex
@@ -41,9 +41,15 @@
             </div>
 
             <%= unless @current_user do %>
-              <div id="telegram-login-button" class="flex items-center justify-center mt-6" phx-update="ignore">
-                <script async src="https://telegram.org/js/telegram-widget.js?11" data-telegram-login="<%= GuildaWeb.AuthController.telegram_bot_username() %>" data-size="large" data-auth-url="<%= Routes.auth_path(@socket, :telegram_callback) %>" data-request-access="write"></script>
-              </div>
+              <%= if Application.get_env(:guilda, :environment) == :dev do %>
+                <div id="telegram-login-button" class="flex items-center justify-center mt-6" phx-update="ignore">
+                  <%= link gettext("Login local"), to: Routes.auth_path(@socket, :telegram_callback, %{username: "guilda", first_name: "Guilda", last_name: "Tech", id: "123456"}) %>
+                </div>
+              <% else %>
+                <div id="telegram-login-button" class="flex items-center justify-center mt-6" phx-update="ignore">
+                  <script async src="https://telegram.org/js/telegram-widget.js?11" data-telegram-login="<%= GuildaWeb.AuthController.telegram_bot_username() %>" data-size="large" data-auth-url="<%= Routes.auth_path(@socket, :telegram_callback) %>" data-request-access="write"></script>
+                </div>
+              <% end %>
             <% end %>
           </div>
         </div>

--- a/lib/guilda_web/templates/page/index.html.leex
+++ b/lib/guilda_web/templates/page/index.html.leex
@@ -41,13 +41,13 @@
             </div>
 
             <%= unless @current_user do %>
-              <%= if Application.get_env(:guilda, :environment) == :dev do %>
+              <%= if Application.get_env(:guilda, :environment) == :prod do %>
                 <div id="telegram-login-button" class="flex items-center justify-center mt-6" phx-update="ignore">
-                  <%= link gettext("Login local"), to: Routes.auth_path(@socket, :telegram_callback, %{username: "guilda", first_name: "Guilda", last_name: "Tech", id: "123456"}) %>
+                  <script async src="https://telegram.org/js/telegram-widget.js?11" data-telegram-login="<%= GuildaWeb.AuthController.telegram_bot_username() %>" data-size="large" data-auth-url="<%= Routes.auth_path(@socket, :telegram_callback) %>" data-request-access="write"></script>
                 </div>
               <% else %>
                 <div id="telegram-login-button" class="flex items-center justify-center mt-6" phx-update="ignore">
-                  <script async src="https://telegram.org/js/telegram-widget.js?11" data-telegram-login="<%= GuildaWeb.AuthController.telegram_bot_username() %>" data-size="large" data-auth-url="<%= Routes.auth_path(@socket, :telegram_callback) %>" data-request-access="write"></script>
+                  <%= link gettext("Login local"), to: Routes.auth_path(@socket, :telegram_callback, %{username: "guilda", first_name: "Guilda", last_name: "Tech", id: "123456"}) %>
                 </div>
               <% end %>
             <% end %>

--- a/test/guilda_web/controllers/auth_controller_test.exs
+++ b/test/guilda_web/controllers/auth_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule GuildaWeb.UserSessionControllerTest do
+defmodule GuildaWeb.AuthControllerTest do
   use GuildaWeb.ConnCase, async: true
 
   alias GuildaWeb.AuthController

--- a/test/guilda_web/controllers/auth_controller_test.exs
+++ b/test/guilda_web/controllers/auth_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule GuildaWeb.UserSessionControllerTest do
+  use GuildaWeb.ConnCase, async: true
+
+  alias GuildaWeb.AuthController
+
+  @fake_data %{
+    "auth_date" => "1610582838",
+    "first_name" => "Jefferson",
+    "hash" => "2d4f588a2f81a6f98d3c94c73d0d0d83238516701e21949d61cf9a0b5e7e2654",
+    "id" => "177382713",
+    "last_name" => "Venerando",
+    "photo_url" => "https://t.me/i/userpic/320/d5ecPIexRS46x_7El-VmWzY_OLpjz1kPBKg_MeHrroA.jpg",
+    "username" => "shamanime"
+  }
+
+  describe "verify_telegram_data/1" do
+    test "checks if the data received in the parameters are from our bot" do
+      {key, _} = AuthController.verify_telegram_data(@fake_data)
+      assert key == :ok
+
+      assert {:error, :invalid_telegram_data} ==
+               AuthController.verify_telegram_data(%{@fake_data | "first_name" => "unknown"})
+    end
+  end
+
+  describe "GET /auth/telegram" do
+    test "registers an user with valid params", %{conn: conn} do
+      conn = get(conn, Routes.auth_path(conn, :telegram_callback, @fake_data))
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
+      refute get_flash(conn, :error)
+    end
+
+    test "returns an error with invalid params", %{conn: conn} do
+      conn = get(conn, Routes.auth_path(conn, :telegram_callback, %{@fake_data | "first_name" => "unknown"}))
+      assert redirected_to(conn) == Routes.page_path(conn, :index)
+      assert get_flash(conn, :error) =~ "Não foi possivel autenticar. Por favor tente novamente mais tarde."
+    end
+  end
+end


### PR DESCRIPTION
Closes #4.

Esse PR foi construído numa live na Twitch.

Adiciona validação nos dados recebidos do Telegram ao clicar no botão de login em produção, e substitui o fluxo de login pra aceitar qualquer coisa em dev.

É necessário configurar o token do bot como uma variável de ambiente.

Também retira a necessidade de usar um domínio personalizado em desenvolvimento (antes era necessário porque o login com Telegram só funciona com domínios).