### PR TITLE
`last_name` não é obrigatório para o Telegram

### DIFF
--- a/lib/guilda/accounts/user.ex
+++ b/lib/guilda/accounts/user.ex
@@ -19,15 +19,16 @@ defmodule Guilda.Accounts.User do
     timestamps()
   end
 
-  @registration_fields ~w(telegram_id username first_name last_name)a
+  @required_registration_fields ~w(telegram_id username first_name)a
+  @optional_registration_fields ~w(last_name)a
 
   @doc """
   A user changeset for registration.
   """
   def registration_changeset(user, attrs) do
     user
-    |> cast(attrs, @registration_fields)
-    |> validate_required(@registration_fields)
+    |> cast(attrs, @required_registration_fields ++ @optional_registration_fields)
+    |> validate_required(@required_registration_fields)
   end
 
   defp validate_email(changeset) do

--- a/lib/guilda_web/controllers/auth_controller.ex
+++ b/lib/guilda_web/controllers/auth_controller.ex
@@ -29,10 +29,10 @@ defmodule GuildaWeb.AuthController do
       {:ok, Map.put(params, "telegram_id", params["id"])}
     end
   else
-    def verify_telegram_data(params) do
+    def verify_telegram_data(params, token \\ nil) do
       {hash, params} = Map.pop(params, "hash")
 
-      secret_key = :crypto.hash(:sha256, telegram_bot_token())
+      secret_key = :crypto.hash(:sha256, token || telegram_bot_token())
 
       data_check_string =
         params

--- a/test/guilda/accounts_test.exs
+++ b/test/guilda/accounts_test.exs
@@ -35,7 +35,6 @@ defmodule Guilda.AccountsTest do
 
       assert %{
                first_name: ["can't be blank"],
-               last_name: ["can't be blank"],
                telegram_id: ["can't be blank"],
                username: ["can't be blank"]
              } = errors_on(changeset)
@@ -45,7 +44,7 @@ defmodule Guilda.AccountsTest do
   describe "change_user_registration/2" do
     test "returns a changeset" do
       assert %Ecto.Changeset{} = changeset = Accounts.change_user_registration(%User{})
-      assert changeset.required == [:telegram_id, :username, :first_name, :last_name]
+      assert changeset.required == [:telegram_id, :username, :first_name]
     end
   end
 

--- a/test/guilda_web/controllers/auth_controller_test.exs
+++ b/test/guilda_web/controllers/auth_controller_test.exs
@@ -3,35 +3,55 @@ defmodule GuildaWeb.AuthControllerTest do
 
   alias GuildaWeb.AuthController
 
-  @fake_data %{
-    "auth_date" => "1610582838",
-    "first_name" => "Jefferson",
-    "hash" => "2d4f588a2f81a6f98d3c94c73d0d0d83238516701e21949d61cf9a0b5e7e2654",
-    "id" => "177382713",
-    "last_name" => "Venerando",
-    "photo_url" => "https://t.me/i/userpic/320/d5ecPIexRS46x_7El-VmWzY_OLpjz1kPBKg_MeHrroA.jpg",
-    "username" => "shamanime"
-  }
+  @jefferson {"1328041770:AAG7GlDdKF2FVEmYjHFNNFKj9UVhDOKmtqc",
+              %{
+                "auth_date" => "1610582838",
+                "first_name" => "Jefferson",
+                "hash" => "2d4f588a2f81a6f98d3c94c73d0d0d83238516701e21949d61cf9a0b5e7e2654",
+                "id" => "177382713",
+                "last_name" => "Venerando",
+                "photo_url" => "https://t.me/i/userpic/320/d5ecPIexRS46x_7El-VmWzY_OLpjz1kPBKg_MeHrroA.jpg",
+                "username" => "shamanime"
+              }}
+
+  @duran {"1328041770:AAG01XO_6mrceJHvNtxKaXsrX2FsvCgHJIU",
+          %{
+            "auth_date" => "1611881130",
+            "first_name" => "Duran, o anão",
+            "hash" => "5c4eb4569880b94e7ab5b0d5d44ab73c6cb04f9535add891f9fed694aca594dc",
+            "id" => "89289679",
+            "username" => "Duran_the_hutt"
+          }}
 
   describe "verify_telegram_data/1" do
     test "checks if the data received in the parameters are from our bot" do
-      {key, _} = AuthController.verify_telegram_data(@fake_data)
+      {token, params} = @jefferson
+      {key, _} = AuthController.verify_telegram_data(params, token)
       assert key == :ok
 
       assert {:error, :invalid_telegram_data} ==
-               AuthController.verify_telegram_data(%{@fake_data | "first_name" => "unknown"})
+               AuthController.verify_telegram_data(%{params | "first_name" => "unknown"}, token)
+
+      {token, params} = @duran
+      {key, _} = AuthController.verify_telegram_data(params, token)
+      assert key == :ok
+
+      assert {:error, :invalid_telegram_data} ==
+               AuthController.verify_telegram_data(%{params | "first_name" => "unknown"}, token)
     end
   end
 
   describe "GET /auth/telegram" do
     test "registers an user with valid params", %{conn: conn} do
-      conn = get(conn, Routes.auth_path(conn, :telegram_callback, @fake_data))
+      {_token, params} = @jefferson
+      conn = get(conn, Routes.auth_path(conn, :telegram_callback, params))
       assert redirected_to(conn) == Routes.page_path(conn, :index)
       refute get_flash(conn, :error)
     end
 
     test "returns an error with invalid params", %{conn: conn} do
-      conn = get(conn, Routes.auth_path(conn, :telegram_callback, %{@fake_data | "first_name" => "unknown"}))
+      {_token, params} = @jefferson
+      conn = get(conn, Routes.auth_path(conn, :telegram_callback, %{params | "first_name" => "unknown"}))
       assert redirected_to(conn) == Routes.page_path(conn, :index)
       assert get_flash(conn, :error) =~ "Não foi possivel autenticar. Por favor tente novamente mais tarde."
     end


### PR DESCRIPTION
Ajusta mais um pouco o fluxo de login.